### PR TITLE
Add IdType support for ItemLookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,17 +57,19 @@ client = Rapa::Client.new(
 
 Available options:
 
-- `:asins`
+- `:id_type`
+- `:item_ids`
 - `:domain`
 - `:related_item_page`
 - `:relationship_type`
 - `:response_groups`
+- `:search_index`
 
 Returns a `Rapa::Responses::ListItemsResponse`.
 
 ```ruby
 response = client.list_items(
-  asins: ["..."],
+  item_ids: ["..."],
   domain: "...",
   response_groups: ["..."],
 )
@@ -181,6 +183,17 @@ Available domain examples:
 - `"fr"`
 - `"in"`
 - `"it"`
+
+### IdType
+
+Available values:
+
+- `"ASIN"`
+- `"EAN"`
+- `"ISBN"`
+- `"JAN"`
+- `"SKU"`
+- `"UPC"`
 
 ### SearchIndex
 

--- a/lib/rapa/client.rb
+++ b/lib/rapa/client.rb
@@ -22,27 +22,32 @@ module Rapa
       end
     end
 
-    # @param asins [Array<String>]
+    # @param item_ids [Array<String>]
     # @param domain [String]
+    # @param id_type [String, nil]
     # @param related_item_page [Integer, nil]
     # @param relationship_type [String, nil]
     # @param response_groups [Array<String>, nil]
     # @return [Rapa::Responses::ListItemsResponse]
     def list_items(
-      asins:,
+      item_ids:,
       domain:,
+      id_type: nil,
       related_item_page: nil,
       relationship_type: nil,
-      response_groups: nil
+      response_groups: nil,
+      search_index: nil
     )
       send_request(
-        asins: asins,
+        item_ids: item_ids,
         domain: domain,
+        id_type: id_type,
         query_class: ::Rapa::Queries::ListItemsQuery,
         related_item_page: related_item_page,
         relationship_type: relationship_type,
         response_class: ::Rapa::Responses::ListItemsResponse,
         response_groups: response_groups,
+        search_index: search_index
       )
     end
 

--- a/lib/rapa/queries/list_items_query.rb
+++ b/lib/rapa/queries/list_items_query.rb
@@ -3,16 +3,28 @@ module Rapa
     class ListItemsQuery < BaseQuery
       OPERATION = "ItemLookup"
 
+      property :IdType
       property :ItemId
+      property :SearchIndex
+
+      # @return [String, nil]
+      def IdType
+        options[:id_type]
+      end
 
       # @return [String]
       def ItemId
-        options[:asins].join(",")
+        options[:item_ids].join(",")
       end
 
       # @note Override
       def Operation
         OPERATION
+      end
+
+      # @return [String, nil]
+      def SearchIndex
+        options[:search_index]
       end
     end
   end


### PR DESCRIPTION
This PR adds `IdType` support for ItemLookup operation.
Note that there is a breaking change in `Rapa::Client#list_items`.