### PR TITLE
価格情報入手メソッドを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Available methods:
 - `#price_lowest_collectible`
 - `#price_lowest_new`
 - `#price_lowest_used`
+- `#price_offer`
 - `#product_group`
 - `#product_type_name`
 - `#publication_date`

--- a/lib/rapa/resources/item_resource.rb
+++ b/lib/rapa/resources/item_resource.rb
@@ -256,6 +256,13 @@ module Rapa
         end
       end
 
+      # @return [Rapa::Price, nil]
+      def price_offer
+        if price_source = source.dig("Offers", "Offer", "OfferListing", "Price")
+          ::Rapa::Price.new(price_source)
+        end
+      end
+
       # @return [String, nil]
       def product_group
         source.dig("ItemAttributes", "ProductGroup")

--- a/test/data/4091250157.json
+++ b/test/data/4091250157.json
@@ -205,6 +205,40 @@
     "TotalCollectible": "2",
     "TotalRefurbished": "0"
   },
+  "Offers": {
+    "TotalOffers": "1",
+    "TotalOfferPages": "1",
+    "MoreOffersUrl": "https://www.amazon.co.jp/gp/offer-listing/4091250157/ref=tmm_other_meta_binding_new_olp_sr?ie=UTF8&condition=new&qid=&sr",
+    "Offer": {
+      "OfferAttributes": {
+        "Condition": "New"
+      },
+      "OfferListing": {
+        "OfferListingId": "rf7%2BToOnZS%2BD6SalCWKQllQAxYU3WPWigqpnT6OuYD%2BdJa%2F74H2nexRuDcIcfYXjuYhIc7UzP85KjDShPxGWYLYRzm%2BeHRWhquF21UkY4ZM%3D",
+        "Price": {
+          "Amount": "596",
+          "CurrencyCode": "JPY",
+          "FormattedPrice": "￥ 596"
+        },
+        "Availability": "在庫あり。",
+        "AvailabilityAttributes": {
+          "AvailabilityType": "now",
+          "MinimumHours": "0",
+          "MaximumHours": "0"
+        },
+        "IsEligibleForSuperSaverShipping": "1",
+        "IsEligibleForPrime": "1"
+      },
+      "LoyaltyPoints": {
+        "Points": "14",
+        "TypicalRedemptionValue": {
+          "Amount": "14",
+          "CurrencyCode": "JPY",
+          "FormattedPrice": "￥ 14"
+        }
+      }
+    }
+  },
   "BrowseNodes": {
     "BrowseNode": [
       {

--- a/test/test_item_resource.rb
+++ b/test/test_item_resource.rb
@@ -238,6 +238,18 @@ class TestItemResource < Petitest::Test
     end
   end
 
+  describe "#price_offer" do
+    let(:subject) do
+      item_resource.price_offer
+    end
+
+    it "returns a Rapa::Price" do
+      assert do
+        subject.is_a?(::Rapa::Price)
+      end
+    end
+  end
+
   describe "#publication_date" do
     let(:subject) do
       item_resource.publication_date


### PR DESCRIPTION
こんばんは。

## 内容

現在、amazonの価格で定価が`LowestNewPrice`からうまく取得できない場合があるようです。

```
     "Title"=>"進撃の巨人(24) (講談社コミックス)"},
   "OfferSummary"=>
    {"LowestNewPrice"=>{"Amount"=>"190", "CurrencyCode"=>"JPY", "FormattedPrice"=>"￥ 190"},
     "LowestUsedPrice"=>{"Amount"=>"143", "CurrencyCode"=>"JPY", "FormattedPrice"=>"￥ 143"},
     "LowestCollectiblePrice"=>{"Amount"=>"250", "CurrencyCode"=>"JPY", "FormattedPrice"=>"￥ 250"},
     "TotalNew"=>"19",
     "TotalUsed"=>"17",
     "TotalCollectible"=>"1",
     "TotalRefurbished"=>"0"},
   "Offers"=>
    {"TotalOffers"=>"1",
     "TotalOfferPages"=>"1",
     "MoreOffersUrl"=>"https://www.amazon.co.jp/gp/offer-listing/406510548X?SubscriptionId=AKIAIGYT55D2WEKVVG2Q&tag=bookwith0a-22&linkCode=xm2&camp=2025&creative=5143&creativeASIN=406510548X",
     "Offer"=>
      {"OfferAttributes"=>{"Condition"=>"New"},
       "OfferListing"=>
        {"OfferListingId"=>"CVfbYpAI1IJP02ROeXIdyC5ic8f9MLDPvDE7%2FKw8ynhEDh25J4gtXzr593Je2LboGRiaXUnk2BthjNSSPoWCDbpV0oyblN48VApFYLNAiDQ%3D",
         "Price"=>{"Amount"=>"463", "CurrencyCode"=>"JPY", "FormattedPrice"=>"￥ 463"},
```

これはサンプルですが、`進撃の巨人(24)` が190円になってしまいます。

## 対策

`Offers`側から取得できる料金も定価の値段ではないかもしれませんが、価格情報の入手手段として、追加したく、プルリクを出しました:pray:
